### PR TITLE
Debian 11 support

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -10,7 +10,11 @@ machines = [
   },
   {
     'iso' => "generic/ubuntu2004",
-    'host'  => "focal"
+    'host' => "focal"
+  },
+  {
+    'iso' => "debian/bullseye64",
+    'host' => "bullseye"
   }
 ]
 
@@ -33,7 +37,7 @@ Vagrant.configure("2") do |config|
   # machine on a private network.
   config.vm.synced_folder ".", "/vagrant", nfs_version: "3"
 
-  (0..1).each do |n|
+  (0..(machines.size - 1)).each do |n|
     node = machines[n]
     config.vm.define node['host'] do |m|
       m.vm.box = node['iso']

--- a/management/utils.py
+++ b/management/utils.py
@@ -196,6 +196,8 @@ def get_os_code():
     if dist == "Debian":
         if version == "10":
             return "Debian10"
+        elif version == "11":
+            return "Debian11"
     elif dist == "Ubuntu":
         if version == "20.04":
             return "Ubuntu2004"

--- a/setup/bootstrap.sh
+++ b/setup/bootstrap.sh
@@ -8,11 +8,17 @@
 
 if [ -z "$TAG" ]; then
 	# Make s
-	OS=`lsb_release -d | sed 's/.*:\s*//'`
-	if [ "$OS" == "Debian GNU/Linux 10 (buster)" -o "$(echo $OS | grep -o 'Ubuntu 20.04')" == "Ubuntu 20.04" ]; then
+	OS=$(lsb_release -d | sed 's/.*:\s*//')
+	if  [ "$OS" == "Debian GNU/Linux 10 (buster)" ] ||
+		[ "$OS" == "Debian GNU/Linux 11 (bullseye)" ] ||
+		[ "$(echo $OS | grep -o 'Ubuntu 20.04')" == "Ubuntu 20.04" ]
+	then
 		TAG=v0.54.POWER.4
 	else
-		echo "This script must be run on a system running Debian 10 OR Ubuntu 20.04 LTS."
+		echo "This script must be run on a system running one of the following OS-es:"
+		echo "* Debian 10 (buster)"
+		echo "* Debian 11 (bullseye)"
+		echo "* Ubuntu 20.04 LTS (Focal Fossa)"
 		exit 1
 	fi
 fi

--- a/setup/functions.sh
+++ b/setup/functions.sh
@@ -232,6 +232,7 @@ function python_version {
 export OS_UNSUPPORTED=0
 export OS_DEBIAN_10=1
 export OS_UBUNTU_2004=2
+export OS_DEBIAN_11=3
 
 function get_os_code {
 	# A lot of if-statements here - dirty code looking tasting today
@@ -241,6 +242,9 @@ function get_os_code {
 	if [[ $ID == "Debian" ]]; then
 		if [[ $VER == "10" ]]; then
 			echo $OS_DEBIAN_10
+			return 0
+		elif [[ $VER == "11" ]]; then
+			echo $OS_DEBIAN_11
 			return 0
 		fi
 	elif [[ $ID == "Ubuntu" ]]; then

--- a/setup/management.sh
+++ b/setup/management.sh
@@ -62,7 +62,7 @@ case $(get_os_code) in
 		hide_output $venv/bin/pip install --upgrade "b2<2.0.0"
 		;;
 	
-	$OS_UBUNTU_2004)
+	$OS_UBUNTU_2004 | $OS_DEBIAN_11)
 		hide_output pip3 install --upgrade "b2sdk==1.7.0"
 		hide_output $venv/bin/pip install --upgrade "b2sdk==1.7.0"
 		;;

--- a/setup/nextcloud.sh
+++ b/setup/nextcloud.sh
@@ -9,8 +9,6 @@ source /etc/mailinabox.conf # load global vars
 
 echo "Installing Nextcloud (contacts/calendar)..."
 
-apt-get purge -qq -y owncloud* # we used to use the package manager
-
 apt_install php php-fpm \
 	php-cli php-sqlite3 php-gd php-imap php-curl php-pear curl \
 	php-dev php-gd php-xml php-mbstring php-zip php-apcu php-json \

--- a/setup/preflight.sh
+++ b/setup/preflight.sh
@@ -11,8 +11,12 @@ fi
 
 # Check that we are running on Debian GNU/Linux, or Ubuntu 20.04
 if [ $(get_os_code) = $OS_UNSUPPORTED ]; then
-	echo "Mail-in-a-Box only supports being installed on Debian 10 or Ubuntu 20.04 LTS, sorry. You are running:"
+	echo "Mail-in-a-Box only supports being installed on one of these operating systems:"
+	echo "* Debian 10 (buster)"
+	echo "* Debian 11 (bullseye)"
+	echo "* Ubuntu 20.04 LTS (Focal Fossa)"
 	echo
+	echo "You're running:"
 	lsb_release -ds
 	echo
 	echo "We can't write scripts that run on every possible setup, sorry."

--- a/setup/webmail.sh
+++ b/setup/webmail.sh
@@ -23,7 +23,7 @@ echo "Installing Roundcube (webmail)..."
 apt_install \
 	dbconfig-common \
 	php-cli php-sqlite3 php-intl php-json php-common php-curl php-ldap \
-	php-gd php-pspell tinymce libjs-jquery libjs-jquery-mousewheel libmagic1 php-mbstring php-gnupg
+	php-gd php-pspell libjs-jquery libjs-jquery-mousewheel libmagic1 php-mbstring php-gnupg
 
 # Install Roundcube from source if it is not already present or if it is out of date.
 # Combine the Roundcube version number with the commit hash of plugins to track


### PR DESCRIPTION
This is a draft PR to add support for Debian 11 (bullseye).

Support for Debian 10 (buster) will remain for the foreseeable future, even though I'd recommend an upgrade anyway.