### PR TITLE
Ability to set custom TTL values for custom DNS records

### DIFF
--- a/management/daemon.py
+++ b/management/daemon.py
@@ -312,7 +312,7 @@ def dns_get_records(qname=None, rtype=None):
 
 	# Make a better data structure.
 	records = [
-        {
+		{
 			"qname": r[0],
 			"rtype": r[1],
 			"value": r[2],

--- a/management/daemon.py
+++ b/management/daemon.py
@@ -359,7 +359,21 @@ def dns_set_record(qname, rtype="A"):
 
 		# Read the record value from the request BODY, which must be
 		# ASCII-only. Not used with GET.
-		value = request.stream.read().decode("ascii", "ignore").strip()
+		rec = request.form
+		value = ""
+		ttl = None
+
+		if isinstance(rec, dict):
+			value = request.form.get("value", "")
+			ttl = request.form.get("ttl", None)
+		else:
+			value = request.stream.read().decode("ascii", "ignore").strip()
+
+		if ttl is not None:
+			try:
+				ttl = int(ttl)
+			except Exception:
+				ttl = None
 
 		if request.method == "GET":
 			# Get the existing records matching the qname and rtype.
@@ -393,7 +407,7 @@ def dns_set_record(qname, rtype="A"):
 				pass
 			action = "remove"
 
-		if set_custom_dns_record(qname, rtype, value, action, env):
+		if set_custom_dns_record(qname, rtype, value, action, env, ttl = ttl):
 			return do_dns_update(env) or "Something isn't right."
 		return "OK"
 

--- a/management/daemon.py
+++ b/management/daemon.py
@@ -316,6 +316,7 @@ def dns_get_records(qname=None, rtype=None):
                 "qname": r[0],
                 "rtype": r[1],
                 "value": r[2],
+				"ttl": r[3],
 		"sort-order": { },
         } for r in records ]
 

--- a/management/daemon.py
+++ b/management/daemon.py
@@ -313,12 +313,13 @@ def dns_get_records(qname=None, rtype=None):
 	# Make a better data structure.
 	records = [
         {
-                "qname": r[0],
-                "rtype": r[1],
-                "value": r[2],
-				"ttl": r[3],
-		"sort-order": { },
-        } for r in records ]
+			"qname": r[0],
+			"rtype": r[1],
+			"value": r[2],
+			"ttl": r[3],
+			"sort-order": { },
+		}
+		for r in records ]
 
 	# To help with grouping by zone in qname sorting, label each record with which zone it is in.
 	# There's an inconsistency in how we handle zones in get_dns_zones and in sort_domains, so

--- a/management/dns_update.py
+++ b/management/dns_update.py
@@ -964,7 +964,7 @@ def write_custom_dns_config(config, env):
 				if rtype in seen_rtypes: continue
 				seen_rtypes.add(rtype)
 
-				values = [(rec[1] if rec[2] is None else {"value": rec[1], "ttl": rec[2]}) for rec in records if rec[0] == rtype]
+				values = [(rec[1] if rec[2] is None else {"value": rec[1], "ttl": min(max(TTL_MIN, rec[2]), TTL_MAX)}) for rec in records if rec[0] == rtype]
 				if len(values) == 1:
 					values = values[0]
 				dns[qname][rtype] = values

--- a/management/dns_update.py
+++ b/management/dns_update.py
@@ -229,7 +229,7 @@ def build_zone(domain, domain_properties, additional_records, env, is_zone=True)
 		# Set the A/AAAA records. Do this early for the PRIMARY_HOSTNAME so that the user cannot override them
 		# and we can provide different explanatory text.
 		records.append((None, "A", env["PUBLIC_IP"], "Required. Sets the IP address of the box.", None))
-		if env.get("PUBLIC_IPV6"): records.append((None, "AAAA", env["PUBLIC_IPV6"], "Required. Sets the IPv6 address of the box."))
+		if env.get("PUBLIC_IPV6"): records.append((None, "AAAA", env["PUBLIC_IPV6"], "Required. Sets the IPv6 address of the box.", None))
 
 		# Add a DANE TLSA record for SMTP.
 		records.append(("_25._tcp", "TLSA", build_tlsa_record(env), "Recommended when DNSSEC is enabled. Advertises to mail servers connecting to the box that mandatory encryption should be used.", None))

--- a/management/templates/custom-dns.html
+++ b/management/templates/custom-dns.html
@@ -53,7 +53,7 @@
           </td>
           <td style="width: 25%;">
             <label for="customdnsTtl" class="col-sm-1 control-label">TTL</label>
-            <input type="number" class="form-control" style="margin-left: 5pt;" id="customdnsTtl" placeholder="86400">
+            <input type="number" class="form-control" style="margin-left: 5pt;" id="customdnsTtl" placeholder="default">
           </td>
         </tr>
       </table>
@@ -280,9 +280,14 @@ function do_set_custom_dns(qname, rtype, value, method) {
     else
       qname = $('#customdnsZone').val();
     rtype = $('#customdnsType').val();
-    value = $('#customdnsValue').val();
+    value = {
+      value: $('#customdnsValue').val(),
+      ttl: $('#customdnsTtl').val()
+    };
     method = 'POST';
   }
+
+  console.log(value)
 
   api(
     "/dns/custom/" + qname + "/" + rtype,

--- a/management/templates/custom-dns.html
+++ b/management/templates/custom-dns.html
@@ -239,7 +239,11 @@ function show_current_custom_dns_update_after_sort() {
         tr.append($('<td class="long"/>').text(data[i].qname));
         tr.append($('<td/>').text(data[i].rtype));
         tr.append($('<td class="long" style="max-width: 40em"/>').text(data[i].value));
-        tr.append($('<td/>').text(data[i].ttl));
+        if (data[i].ttl) {
+          tr.append($('<td/>').text(data[i].ttl));
+        } else {
+          tr.append($('<td/>').html('<i class="">default</i>'));
+        }
         tr.append($('<td>[<a href="#" onclick="return delete_custom_dns_record(this)">delete</a>]</td>'));
       }
 }

--- a/management/templates/custom-dns.html
+++ b/management/templates/custom-dns.html
@@ -44,9 +44,19 @@
     </div>
   </div>
   <div class="form-group">
-    <label for="customdnsValue" class="col-sm-1 control-label">Value</label>
     <div class="col-sm-10">
-      <input type="text" class="form-control" id="customdnsValue" placeholder="">
+      <table>
+        <tr style="width: 100%;">
+          <td style="width: 75%;">
+            <label for="customdnsValue" class="control-label">Value</label>
+            <input type="text" class="form-control" id="customdnsValue" placeholder="">
+          </td>
+          <td style="width: 25%;">
+            <label for="customdnsTtl" class="col-sm-1 control-label">TTL</label>
+            <input type="number" class="form-control" style="margin-left: 5pt;" id="customdnsTtl" placeholder="86400">
+          </td>
+        </tr>
+      </table>
       <div id="customdnsTypeHint" class="text-info" style="margin-top: .5em"></div>
     </div>
   </div>
@@ -57,7 +67,7 @@
   </div>
 </form>
 
-<div style="text-align: right; font-size; 90%; margin-top: 1em;">
+<div style="text-align: right; font-size: 90%; margin-top: 1em;">
   sort by:
   <a href="#" onclick="window.miab_custom_dns_data_sort_order='qname'; show_current_custom_dns_update_after_sort(); return false;">domain name</a>
   |
@@ -68,10 +78,11 @@
     <th>Domain Name</th>
     <th>Record Type</th>
     <th>Value</th>
+    <th>TTL</th>
     <th></th>
   </thead>
   <tbody>
-    <tr><td colspan="4">Loading...</td></tr>
+    <tr><td colspan="5">Loading...</td></tr>
   </tbody>
 </table>
 
@@ -214,7 +225,7 @@ function show_current_custom_dns_update_after_sort() {
       var last_zone = null;
       for (var i = 0; i < data.length; i++) {
         if (sort_key == "qname" && data[i].zone != last_zone) {
-          var r = $("<tr><th colspan=4 style='background-color: #EEE'></th></tr>");
+          var r = $("<tr><th colspan=5 style='background-color: #EEE'></th></tr>");
           r.find("th").text(data[i].zone);
           tbody.append(r);
           last_zone = data[i].zone;
@@ -228,6 +239,7 @@ function show_current_custom_dns_update_after_sort() {
         tr.append($('<td class="long"/>').text(data[i].qname));
         tr.append($('<td/>').text(data[i].rtype));
         tr.append($('<td class="long" style="max-width: 40em"/>').text(data[i].value));
+        tr.append($('<td/>').text(data[i].ttl));
         tr.append($('<td>[<a href="#" onclick="return delete_custom_dns_record(this)">delete</a>]</td>'));
       }
 }

--- a/management/web_update.py
+++ b/management/web_update.py
@@ -55,7 +55,7 @@ def get_web_domains(env, include_www_redirects=True, include_auto=True, exclude_
 def get_domains_with_a_records(env):
 	domains = set()
 	dns = get_custom_dns_config(env)
-	for domain, rtype, value in dns:
+	for domain, rtype, value, ttl in dns:
 		if rtype == "CNAME" or (rtype in ("A", "AAAA") and value not in ("local", env['PUBLIC_IP'])):
 			domains.add(domain)
 	return domains


### PR DESCRIPTION
Essentially what the title says; right now all records are published with a TTL of 86400 seconds (1 day), which may be inadequate for some folks relying on the box for Dynamic DNS. There are also the advantages inherent to be able to set the TTL per-record.

**Users will not be required to set TTL values if they choose not to.** Just leave the TTL field empty and the box will set it for you.