### PR TITLE
Add a way for users to specify custom upstream directives

### DIFF
--- a/conf/nginx-alldomains.conf
+++ b/conf/nginx-alldomains.conf
@@ -31,7 +31,7 @@
 		fastcgi_param SCRIPT_FILENAME /usr/local/lib/z-push/index.php;
 		fastcgi_param PHP_VALUE "include_path=.:/usr/share/php:/usr/share/pear:/usr/share/awl/inc";
 		fastcgi_read_timeout 630;
-		fastcgi_pass php-fpm;
+		fastcgi_pass php-default;
 
 		# Outgoing mail also goes through this endpoint, so increase the maximum
 		# file upload limit to match the corresponding Postfix limit.
@@ -41,7 +41,7 @@
 		include fastcgi_params;
 		fastcgi_param SCRIPT_FILENAME /usr/local/lib/z-push/autodiscover/autodiscover.php;
 		fastcgi_param PHP_VALUE "include_path=.:/usr/share/php:/usr/share/pear:/usr/share/awl/inc";
-		fastcgi_pass php-fpm;
+		fastcgi_pass php-default;
 	}
 
 	# Disable viewing dotfiles (.htaccess, .svn, .git, etc.)

--- a/conf/nginx-primaryonly.conf
+++ b/conf/nginx-primaryonly.conf
@@ -33,7 +33,7 @@
 		fastcgi_split_path_info ^/mail(/.*)()$;
 		fastcgi_index index.php;
 		fastcgi_param SCRIPT_FILENAME /usr/local/lib/roundcubemail/$fastcgi_script_name;
-		fastcgi_pass php-fpm;
+		fastcgi_pass php-default;
 
 		# Outgoing mail also goes through this endpoint, so increase the maximum
 		# file upload limit to match the corresponding Postfix limit.
@@ -60,7 +60,7 @@
 			index index.php;
 			include fastcgi_params;
 			fastcgi_param SCRIPT_FILENAME /usr/local/lib/owncloud/$1/$2;
-			fastcgi_pass php-fpm;
+			fastcgi_pass php-default;
 		}
 	}
 	location ~ ^(/cloud)((?:/ocs)?/[^/]+\.php)(/.*)?$ {
@@ -77,7 +77,7 @@
 		fastcgi_param MOD_X_ACCEL_REDIRECT_ENABLED on;
 		fastcgi_param MOD_X_ACCEL_REDIRECT_PREFIX /owncloud-xaccel;
 		fastcgi_read_timeout 630;
-		fastcgi_pass php-fpm;
+		fastcgi_pass php-default;
 		client_max_body_size 1G;
 		fastcgi_buffers 64 4K;
 	}

--- a/conf/nginx-top.conf
+++ b/conf/nginx-top.conf
@@ -6,6 +6,11 @@
 ##       If you modify any system configuration you are on
 ##       your own --- please do not ask for help from us.
 
+# This socket is reserved for Mail-in-a-Box-specific services
+upstream php-default {
+	server unix:/var/run/php/php-default.sock
+}
+
 upstream php-fpm {
 	server unix:/var/run/php/php{{phpver}}-fpm.sock;
 }

--- a/conf/nginx-top.conf
+++ b/conf/nginx-top.conf
@@ -8,7 +8,7 @@
 
 # This socket is reserved for Mail-in-a-Box-specific services
 upstream php-default {
-	server unix:/var/run/php/php-default.sock
+	server unix:/var/run/php/php-default.sock;
 }
 
 upstream php-fpm {

--- a/management/web_update.py
+++ b/management/web_update.py
@@ -125,7 +125,9 @@ def do_web_update(env):
 		with open(nginx_upstream_include, "a+") as f:
 			f.writelines([
 				f"# Add your nginx-wide configurations here.\n",
-				"# 'php-fpm' is already defined.\n\n"
+				"# The following names are already defined:\n\n",
+				"# # php-default: The php socket used for apps managed by the box. (Roundcube, Z-Push, Nextcloud, etc.) - DO NOT USE!",
+				"# # php-fpm: A php socket not managed by the box. Feel free to use it for your PHP applications"
 			])
 
 	nginx_conf += "\ninclude %s;\n" % (nginx_upstream_include)

--- a/management/web_update.py
+++ b/management/web_update.py
@@ -118,6 +118,17 @@ def do_web_update(env):
 	# Build an nginx configuration file.
 	nginx_conf = open(os.path.join(os.path.dirname(__file__), "../conf/nginx-top.conf")).read()
 	nginx_conf = re.sub("{{phpver}}", get_php_version(), nginx_conf)
+	
+	# Add upstream additions
+	nginx_upstream_include = os.path.join(env["STORAGE_ROOT"], "www", ".upstream.conf")
+	if not os.path.exists(nginx_upstream_include):
+		with open(nginx_upstream_include, "a+") as f:
+			f.writelines([
+				f"# Add your nginx-wide configurations here.\n",
+				"# 'php-fpm' is already defined.\n\n"
+			])
+
+	nginx_conf += "\ninclude %s;\n" % (nginx_upstream_include)
 
 	# Load the templates.
 	template0 = open(os.path.join(os.path.dirname(__file__), "../conf/nginx.conf")).read()

--- a/management/web_update.py
+++ b/management/web_update.py
@@ -126,8 +126,8 @@ def do_web_update(env):
 			f.writelines([
 				f"# Add your nginx-wide configurations here.\n",
 				"# The following names are already defined:\n\n",
-				"# # php-default: The php socket used for apps managed by the box. (Roundcube, Z-Push, Nextcloud, etc.) - DO NOT USE!",
-				"# # php-fpm: A php socket not managed by the box. Feel free to use it for your PHP applications"
+				"# # php-default: The php socket used for apps managed by the box. (Roundcube, Z-Push, Nextcloud, etc.) - DO NOT USE!\n",
+				"# # php-fpm: A php socket not managed by the box. Feel free to use it for your PHP applications\n"
 			])
 
 	nginx_conf += "\ninclude %s;\n" % (nginx_upstream_include)

--- a/setup/web.sh
+++ b/setup/web.sh
@@ -101,6 +101,8 @@ cp /etc/php/$(php_version)/fpm/pool.d/www.conf /etc/php/$(php_version)/fpm/pool.
 management/editconf.py /etc/php/$(php_version)/fpm/pool.d/miab.conf -c ';' \
         listen=/run/php/php-default.sock
 
+sed -i 's/\[www\]/[miab]/' /etc/php/$(php_version)/fpm/pool.d/miab.conf
+
 # Other nginx settings will be configured by the management service
 # since it depends on what domains we're serving, which we don't know
 # until mail accounts have been created.

--- a/setup/web.sh
+++ b/setup/web.sh
@@ -95,6 +95,12 @@ else
                 pm.max_spare_servers=18
 fi
 
+# Duplicate the socket to isolate MiaB apps from user apps that happen to run php 
+cp /etc/php/$(php_version)/fpm/pool.d/www.conf /etc/php/$(php_version)/fpm/pool.d/miab.conf
+
+management/editconf.py /etc/php/$(php_version)/fpm/pool.d/miab.conf -c ';' \
+        listen=/run/php/php-default.sock
+
 # Other nginx settings will be configured by the management service
 # since it depends on what domains we're serving, which we don't know
 # until mail accounts have been created.


### PR DESCRIPTION
Upstream directives like the following:

```
upstream {
    server 127.0.0.1:4269
    server 127.0.0.2:4269
}
```

Cannot be specified inside `server {}` blocks. The regular `/home/user-data/www/<domain>.conf` file is already included inside a server block - that means top-level directives like `upstream` were impossible until that point.

A new file will be placed at `/home/user-data/www/.upstream.conf` - anything written there is included before any and all server blocks.