### PR TITLE
feat: Gmail / IMAP importer (commandline only)

### DIFF
--- a/conf/offlineimap-in.conf
+++ b/conf/offlineimap-in.conf
@@ -1,0 +1,41 @@
+# For migrating Gmail/IMAP to dovecot / Mail in a box
+# used with management/imapimport.py
+# Import side
+
+[DEFAULT]
+localfolders = {STORAGE_ROOT}/mail/mailboxes/{domain}/{user}
+scriptpath = {STORAGE_ROOT}/mail/mailboxes
+timestamp = %(localfolders)s/syncstart.timestamp
+sslcacertfile = /etc/ssl/certs/ca-certificates.crt
+synclabels = yes
+
+[general]
+accounts = Import
+socktimeout = 60
+
+[Account Import]
+remoterepository = Source
+localrepository = In
+presynchook = [ -f %(timestamp)s ] || touch %(timestamp)s
+# Set file modified time to match the mail message & force dovecot reindex
+postsynchook = \
+    find %(localfolders)s -newer %(timestamp)s -name '*,FMD5=*' -print0 \
+    | xargs -r0 %(scriptpath)s/set-received-mtime \
+    && rm %(timestamp)s \
+    && find %(localfolders)s -maxdepth 2 -type f -path '*/.[^.]*' -name 'dovecot*' -delete
+#maxage = 2022-05-01
+
+[Repository Source]
+# Gmail or IMAP
+type = {type}
+remotehost = {remotehost}
+remoteport = {remoteport}
+remoteuser = {remoteuser}
+remotepass = {remotepass}
+folderfilter = lambda folder: folder in {folderlist} if {folderlist} else folder
+nametrans = lambda folder: '.' + '{remoteuser}'.translate(''.maketrans('','',"""!#$%%&'*+/=?^`|\{{}}~"().,:;<>[]""")) + '.' + folder.replace('[Gmail]/', '').replace(' ', '_').replace('/', '.')
+readonly = True
+
+[Repository In]
+# GmailMaildir or Maildir
+type = {localtype}

--- a/conf/offlineimap-in.conf
+++ b/conf/offlineimap-in.conf
@@ -6,6 +6,7 @@
 localfolders = {STORAGE_ROOT}/mail/mailboxes/{domain}/{user}
 scriptpath = {STORAGE_ROOT}/mail/mailboxes
 timestamp = %(localfolders)s/syncstart.timestamp
+removepunct = ''.maketrans('','',"""!#$%%&'*+/=?^`|\{{}}~"().,:;<>[]""")
 sslcacertfile = /etc/ssl/certs/ca-certificates.crt
 synclabels = yes
 
@@ -32,10 +33,11 @@ remotehost = {remotehost}
 remoteport = {remoteport}
 remoteuser = {remoteuser}
 remotepass = {remotepass}
-folderfilter = lambda folder: folder in {folderlist} if {folderlist} else folder
-nametrans = lambda folder: '.' + '{remoteuser}'.translate(''.maketrans('','',"""!#$%%&'*+/=?^`|\{{}}~"().,:;<>[]""")) + '.' + folder.replace('[Gmail]/', '').replace(' ', '_').replace('/', '.')
+folderfilter = lambda folder: folder in {folderlist} if {folderlist} else folder == '[Gmail]/All Mail' if '{type}' == 'Gmail' else folder
+nametrans = lambda folder: '.' + '{remoteuser}'.translate(%(removepunct)s) + '.' + folder.replace('[Gmail]/', '').replace(' ', '_').replace('/', '.')
 readonly = True
 
 [Repository In]
 # GmailMaildir or Maildir
 type = {localtype}
+nametrans = lambda folder: folder.strip('.').replace('_', ' ').replace('.', '/')

--- a/conf/offlineimap-in.conf
+++ b/conf/offlineimap-in.conf
@@ -11,12 +11,12 @@ sslcacertfile = /etc/ssl/certs/ca-certificates.crt
 synclabels = yes
 
 [general]
-accounts = Import
+accounts = Import-{user}@{domain}
 socktimeout = 60
 
-[Account Import]
-remoterepository = Source
-localrepository = In
+[Account Import-{user}@{domain}]
+remoterepository = RMT-{remoteuser}
+localrepository = LCL-{user}@{domain}
 presynchook = [ -f %(timestamp)s ] || touch %(timestamp)s
 # Set file modified time to match the mail message & force dovecot reindex
 postsynchook = \
@@ -26,7 +26,7 @@ postsynchook = \
     && find %(localfolders)s -maxdepth 2 -type f -path '*/.[^.]*' -name 'dovecot*' -delete
 #maxage = 2022-05-01
 
-[Repository Source]
+[Repository RMT-{remoteuser}]
 # Gmail or IMAP
 type = {type}
 remotehost = {remotehost}
@@ -37,7 +37,7 @@ folderfilter = lambda folder: folder in {folderlist} if {folderlist} else folder
 nametrans = lambda folder: '.' + '{remoteuser}'.translate(%(removepunct)s) + '.' + folder.replace('[Gmail]/', '').replace(' ', '_').replace('/', '.')
 readonly = True
 
-[Repository In]
+[Repository LCL-{user}@{domain}]
 # GmailMaildir or Maildir
 type = {localtype}
 nametrans = lambda folder: folder.strip('.').replace('_', ' ').replace('.', '/')

--- a/conf/offlineimap-out.conf
+++ b/conf/offlineimap-out.conf
@@ -1,0 +1,30 @@
+# For migrating Gmail/IMAP to dovecot / Mail in a box
+# used with management/imapimport.py
+# Export side
+
+[DEFAULT]
+localfolders = {STORAGE_ROOT}/mail/mailboxes/{domain}/{user}
+sslcacertfile = /etc/ssl/certs/ca-certificates.crt
+synclabels = yes
+
+[general]
+accounts = Export
+socktimeout = 60
+
+[Account Export]
+remoterepository = Target
+localrepository = Out
+
+[Repository Out]
+type = Maildir
+folderfilter = lambda folder: folder in {folderlist} if {folderlist} else folder
+readonly = True
+
+[Repository Target]
+# Gmail or IMAP
+type = {type}
+remotehost = {remotehost}
+remoteport = {remoteport}
+remoteuser = {remoteuser}
+remotepass = {remotepass}
+nametrans = lambda folder: '.' + folder.replace(' ', '_').replace('/', '.')

--- a/conf/offlineimap-out.conf
+++ b/conf/offlineimap-out.conf
@@ -8,19 +8,14 @@ sslcacertfile = /etc/ssl/certs/ca-certificates.crt
 synclabels = yes
 
 [general]
-accounts = Export
+accounts = Export-{user}@{domain}
 socktimeout = 60
 
-[Account Export]
-remoterepository = Target
-localrepository = Out
+[Account Export-{user}@{domain}]
+remoterepository = RMT-{remoteuser}
+localrepository = LCL-{user}@{domain}
 
-[Repository Out]
-type = Maildir
-nametrans = lambda folder: folder.strip('.').replace('_', ' ').replace('.', '/')
-readonly = True
-
-[Repository Target]
+[Repository RMT-{remoteuser}]
 # Gmail or IMAP
 type = {type}
 remotehost = {remotehost}
@@ -29,3 +24,8 @@ remoteuser = {remoteuser}
 remotepass = {remotepass}
 folderfilter = lambda folder: folder in {folderlist} if {folderlist} else folder.endswith('All Mail') and not folder.startswith('[') if '{type}' == 'Gmail' else folder
 nametrans = lambda folder: '.' + folder.replace('[Gmail]/', '').replace(' ', '_').replace('/', '.')
+
+[Repository LCL-{user}@{domain}]
+type = Maildir
+nametrans = lambda folder: folder.strip('.').replace('_', ' ').replace('.', '/')
+readonly = True

--- a/conf/offlineimap-out.conf
+++ b/conf/offlineimap-out.conf
@@ -17,7 +17,7 @@ localrepository = Out
 
 [Repository Out]
 type = Maildir
-folderfilter = lambda folder: folder in {folderlist} if {folderlist} else folder
+nametrans = lambda folder: folder.strip('.').replace('_', ' ').replace('.', '/')
 readonly = True
 
 [Repository Target]
@@ -27,4 +27,5 @@ remotehost = {remotehost}
 remoteport = {remoteport}
 remoteuser = {remoteuser}
 remotepass = {remotepass}
-nametrans = lambda folder: '.' + folder.replace(' ', '_').replace('/', '.')
+folderfilter = lambda folder: folder in {folderlist} if {folderlist} else folder.endswith('All Mail') and not folder.startswith('[') if '{type}' == 'Gmail' else folder
+nametrans = lambda folder: '.' + folder.replace('[Gmail]/', '').replace(' ', '_').replace('/', '.')

--- a/management/imapimport.py
+++ b/management/imapimport.py
@@ -6,6 +6,8 @@ import sys
 import re
 import shutil
 import subprocess
+import string
+import random
 
 
 def run_cmd(config, info):
@@ -70,7 +72,8 @@ def importexport_cmdline(exec, cmd, type, user, remoteuser, remotepass, remoteho
 
 	# Create the config from template
 	mailroot = os.path.join(env['STORAGE_ROOT'], 'mail', 'mailboxes')
-	config = os.path.join(mailroot, domain, user, 'offlineimaprc')
+	filename = ''.join(random.choices(string.ascii_letters, k=12))
+	config = os.path.join(mailroot, domain, user, filename)
 	if cmd == 'import':
 		template = os.path.join(mailroot, 'offlineimap-in.conf')
 	else:
@@ -86,6 +89,7 @@ def importexport_cmdline(exec, cmd, type, user, remoteuser, remotepass, remoteho
 
 	# Run
 	output = run_cmd(config, options.get('info'))
+	os.remove(config)
 
 	if not options.get('quiet'):
 		print(output)

--- a/management/imapimport.py
+++ b/management/imapimport.py
@@ -1,0 +1,114 @@
+#!/usr/local/lib/mailinabox/env/bin/python
+# Gmail/IMAP import/export
+
+import os
+import sys
+import re
+import shutil
+import subprocess
+
+
+def run_cmd(cmd, config):
+	from decimal import Decimal, getcontext
+	getcontext().prec = 3
+
+	args = ['su', 'mail', '-g', 'mail', '-s', '/bin/bash', '-c']
+	exe = f'/usr/local/lib/mailinabox/env/bin/offlineimap -c {config} '
+	if cmd in ('import', 'export'):
+		exe += '-o'
+	else:
+		exe += '--info'
+	args.append(exe)
+
+	print('')
+	output = ''
+
+	# example: Copy message UID 118742 (8/137) Source:[Gmail]/All Mail -> In:.Import
+	regex = re.compile(r'Copy message UID.*?\((\d+)/(\d+)\)')
+
+	try:
+		process = subprocess.Popen(args, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+		for line in iter(process.stdout.readline, b''):
+			text = line.decode('utf8')
+
+			# output progress %
+			match = regex.search(text)
+			if match:
+				percent = ( Decimal(match.group(1)) / Decimal(match.group(2)) ) * 100
+				print(f'\r{percent}%   ', end='')
+			else:
+				output += text
+
+			if process.returncode:
+				break
+	except Exception:
+		process.kill()
+		raise
+
+	print('\rDone!\n')
+	return output
+
+def importexport_cmdline(exec, cmd, type, user, remoteuser, remotepass, remotehost, remoteport, *folderlist):
+	try:
+		remoteport = int(remoteport)
+		user, sep, domain = user.rpartition('@')
+		if cmd not in ('import', 'export', 'info') or type not in ('Gmail', 'IMAP') or not user:
+			raise SyntaxError('Error in cmd or type or user parameters')
+
+		localtype = 'Maildir'
+		if cmd in ('import', 'info') and type == 'Gmail':
+			localtype = 'GmailMaildir'
+			if not folderlist:
+				folderlist = ('[Gmail]/All Mail',)
+
+	except Exception as e:
+		print(usage)
+		raise SyntaxError(f'Error in parameters: {locals()}')
+
+	context = locals()
+	from utils import load_environment
+	env = load_environment()
+	context.update(env)
+
+	# Create the config from template
+	mailroot = os.path.join(env['STORAGE_ROOT'], 'mail', 'mailboxes')
+	config = os.path.join(mailroot, 'offlineimaprc')
+	if cmd in ('import', 'info'):
+		template = os.path.join(mailroot, 'offlineimap-in.conf')
+	else:
+		template = os.path.join(mailroot, 'offlineimap-out.conf')
+
+	with open(template, 'r') as fd:
+		text = fd.read()
+	render = text.format(**context)
+
+	with open(config, 'w') as fd:
+		fd.write(render)
+	shutil.chown(config, 'mail', 'mail')
+
+	# Run
+	output = run_cmd(cmd, config)
+	print(output)
+
+
+usage = """
+Mail in a box Gmail/IMAP import/export tool
+imapimport.py cmd type user remoteuser remotepass remoteserver remoteport [folders]
+cmd		import/export/info
+type		Gmail/IMAP
+user		local mail username, usually user@domain.tld
+remoteuser	remote server username, usually user@domain.tld
+remotepass	remote server password
+remotehost	remote server DNS name
+remoteport	remote server port number, e.g. 993
+[folders]	space separated list of source folders. If omitted for Gmail imports
+		only [Gmail]/All Mail will be imported, otherwise all folders will be synced
+"""
+
+if __name__ == "__main__":
+	# Commandline tool
+	try:
+		importexport_cmdline(*sys.argv)
+	except Exception:
+		print(usage)
+		raise

--- a/management/imapimport.py
+++ b/management/imapimport.py
@@ -8,18 +8,18 @@ import shutil
 import subprocess
 
 
-def run_cmd(cmd, config):
+def run_cmd(cmd, config, info):
 	from decimal import Decimal, getcontext
 	getcontext().prec = 3
 
 	args = ['su', 'mail', '-g', 'mail', '-s', '/bin/bash', '-c']
 	exe = f'/usr/local/lib/mailinabox/env/bin/offlineimap -c {config} '
-	if cmd in ('import', 'export'):
-		exe += '-o'
-	else:
+	if info:
 		exe += '--info'
-	args.append(exe)
+	else:
+		exe += '-o'
 
+	args.append(exe)
 	print('')
 	output = ''
 
@@ -35,7 +35,7 @@ def run_cmd(cmd, config):
 			match = regex.search(text)
 			if match:
 				percent = ( Decimal(match.group(1)) / Decimal(match.group(2)) ) * 100
-				print(f'\r{percent}%   ', end='')
+				print(f'\r{percent}% ', end='')
 			else:
 				output += text
 
@@ -48,18 +48,16 @@ def run_cmd(cmd, config):
 	print('\rDone!\n')
 	return output
 
-def importexport_cmdline(exec, cmd, type, user, remoteuser, remotepass, remotehost, remoteport, *folderlist):
+def importexport_cmdline(exec, cmd, type, user, remoteuser, remotepass, remotehost, remoteport, *folderlist, **options):
 	try:
 		remoteport = int(remoteport)
 		user, sep, domain = user.rpartition('@')
-		if cmd not in ('import', 'export', 'info') or type not in ('Gmail', 'IMAP') or not user:
-			raise SyntaxError('Error in cmd or type or user parameters')
+		if cmd not in ('import', 'export') or type not in ('Gmail', 'IMAP') or not user:
+			raise SyntaxError('Error in cmd, type or user parameters')
 
 		localtype = 'Maildir'
-		if cmd in ('import', 'info') and type == 'Gmail':
+		if type == 'Gmail' and cmd == 'import':
 			localtype = 'GmailMaildir'
-			if not folderlist:
-				folderlist = ('[Gmail]/All Mail',)
 
 	except Exception as e:
 		print(usage)
@@ -73,7 +71,7 @@ def importexport_cmdline(exec, cmd, type, user, remoteuser, remotepass, remoteho
 	# Create the config from template
 	mailroot = os.path.join(env['STORAGE_ROOT'], 'mail', 'mailboxes')
 	config = os.path.join(mailroot, 'offlineimaprc')
-	if cmd in ('import', 'info'):
+	if cmd == 'import':
 		template = os.path.join(mailroot, 'offlineimap-in.conf')
 	else:
 		template = os.path.join(mailroot, 'offlineimap-out.conf')
@@ -87,28 +85,48 @@ def importexport_cmdline(exec, cmd, type, user, remoteuser, remotepass, remoteho
 	shutil.chown(config, 'mail', 'mail')
 
 	# Run
-	output = run_cmd(cmd, config)
-	print(output)
+	output = run_cmd(cmd, config, options.get('info'))
+
+	if not options.get('quiet'):
+		print(output)
 
 
 usage = """
 Mail in a box Gmail/IMAP import/export tool
-imapimport.py cmd type user remoteuser remotepass remoteserver remoteport [folders]
-cmd		import/export/info
-type		Gmail/IMAP
+imapimport.py [options] cmd type user remoteuser remotepass remoteserver remoteport [folders]
+Options:
+-i		remote and local folder information
+-q		quiet, don't print the output from the transfer. Progress is always printed
+
+Parameters:
+cmd		import or export
+type		Gmail or IMAP
 user		local mail username, usually user@domain.tld
 remoteuser	remote server username, usually user@domain.tld
 remotepass	remote server password
 remotehost	remote server DNS name
 remoteport	remote server port number, e.g. 993
-[folders]	space separated list of source folders. If omitted for Gmail imports
-		only [Gmail]/All Mail will be imported, otherwise all folders will be synced
+[folders]	space separated list of remote (Gmail/IMAP) folders. If omitted for Gmail,
+		only '[Gmail]/All Mail' will be migrated, otherwise all folders will be allowed
+
+*** Important Note: Once an import has started you will need to make the folder visible
+                    in webmail settings.
 """
 
 if __name__ == "__main__":
 	# Commandline tool
+	args = []
+	options = {}
+	for arg in sys.argv:
+		if arg == '-i':
+			options['info'] = True
+		elif arg == '-q':
+			options['quiet'] = True
+		else:
+			args.append(arg)
+
 	try:
-		importexport_cmdline(*sys.argv)
+		importexport_cmdline(*args, **options)
 	except Exception:
 		print(usage)
 		raise

--- a/management/imapimport.py
+++ b/management/imapimport.py
@@ -8,7 +8,7 @@ import shutil
 import subprocess
 
 
-def run_cmd(cmd, config, info):
+def run_cmd(config, info):
 	from decimal import Decimal, getcontext
 	getcontext().prec = 3
 
@@ -85,7 +85,7 @@ def importexport_cmdline(exec, cmd, type, user, remoteuser, remotepass, remoteho
 	shutil.chown(config, 'mail', 'mail')
 
 	# Run
-	output = run_cmd(cmd, config, options.get('info'))
+	output = run_cmd(config, options.get('info'))
 
 	if not options.get('quiet'):
 		print(output)

--- a/management/imapimport.py
+++ b/management/imapimport.py
@@ -70,7 +70,7 @@ def importexport_cmdline(exec, cmd, type, user, remoteuser, remotepass, remoteho
 
 	# Create the config from template
 	mailroot = os.path.join(env['STORAGE_ROOT'], 'mail', 'mailboxes')
-	config = os.path.join(mailroot, 'offlineimaprc')
+	config = os.path.join(mailroot, domain, user, 'offlineimaprc')
 	if cmd == 'import':
 		template = os.path.join(mailroot, 'offlineimap-in.conf')
 	else:

--- a/management/imapimport.py
+++ b/management/imapimport.py
@@ -51,22 +51,22 @@ def run_cmd(config, info):
 	return output
 
 def importexport_cmdline(exec, cmd, type, user, remoteuser, remotepass, remotehost, remoteport, *folderlist, **options):
-	try:
-		remoteport = int(remoteport)
-		user, sep, domain = user.rpartition('@')
-		if cmd not in ('import', 'export') or type not in ('Gmail', 'IMAP') or not user:
-			raise SyntaxError('Error in cmd, type or user parameters')
+	from utils import load_environment
 
-		localtype = 'Maildir'
-		if type == 'Gmail' and cmd == 'import':
-			localtype = 'GmailMaildir'
+	remoteport = int(remoteport)
+	user, sep, domain = user.rpartition('@')
+	if cmd not in ('import', 'export'):
+		raise SyntaxError("Error: cmd can be 'import' or 'export'")
+	if type not in ('Gmail', 'IMAP'):
+		raise SyntaxError("Error: type can be 'Gmail' or 'IMAP'")
+	if not user:
+		raise SyntaxError("Error: user should be in the form 'user@host'")
 
-	except Exception as e:
-		print(usage)
-		raise SyntaxError(f'Error in parameters: {locals()}')
+	localtype = 'Maildir'
+	if type == 'Gmail' and cmd == 'import':
+		localtype = 'GmailMaildir'
 
 	context = locals()
-	from utils import load_environment
 	env = load_environment()
 	context.update(env)
 

--- a/setup/imapimport.sh
+++ b/setup/imapimport.sh
@@ -8,7 +8,7 @@ echo "Installing IMAP/Gmail importer..."
 # DEPENDENCIES
 # Install offlineimap to the venv
 venv=/usr/local/lib/mailinabox/env
-hide_output $venv/bin/pip install --upgrade distro imaplib2
+hide_output $venv/bin/pip install --upgrade distro imaplib2 rfc6555
 hide_output $venv/bin/pip install --upgrade git+https://github.com/offlineIMAP/offlineimap3.git@v8.0.0
 
 # CONFIGURATION

--- a/setup/imapimport.sh
+++ b/setup/imapimport.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+source /etc/mailinabox.conf # get global vars
+source setup/functions.sh # load our functions
+
+echo "Installing IMAP/Gmail importer..."
+
+# DEPENDENCIES
+# Install offlineimap to the venv
+venv=/usr/local/lib/mailinabox/env
+hide_output $venv/bin/pip install --upgrade distro imaplib2
+hide_output $venv/bin/pip install --upgrade git+https://github.com/offlineIMAP/offlineimap3.git@v8.0.0
+
+# CONFIGURATION
+maildir=$STORAGE_ROOT/mail/mailboxes
+
+# offlineimap helper script
+scriptname=set-received-mtime
+hide_output cp tools/$scriptname $maildir
+chown mail:mail $maildir/$scriptname
+
+# config templates
+hide_output cp conf/offlineimap* $maildir
+chown mail:mail $maildir/offlineimap*

--- a/setup/start.sh
+++ b/setup/start.sh
@@ -128,6 +128,7 @@ source setup/nextcloud.sh
 source setup/zpush.sh
 source setup/management.sh
 source setup/munin.sh
+source setup/imapimport.sh
 
 # Create a shorthand alias for the cli interface
 cat > /usr/local/sbin/miabadm << EOF;

--- a/tools/set-received-mtime
+++ b/tools/set-received-mtime
@@ -1,0 +1,38 @@
+#! /bin/sh -e
+
+receivedHeader() {
+    < "$1" sed -n -e '
+        /^Received:/{
+            h
+            : o
+            n
+            /^[ \t]/ {
+                H
+                b o
+            }
+            x
+            s/\n//g
+            s/Received:\s*//
+            s/.*;\s*//
+            p
+            q
+        }
+        /^$/q'
+}
+
+dateHeader() {
+    < "$1" sed -n -e '
+        /^Date:/{
+            s/Date:\s*//
+            p
+            q
+        }
+        /^$/q'
+}
+
+for message
+do
+    mtime="$(receivedHeader "$message")"
+    [ -z "$mtime" ] && mtime="$(dateHeader "$message")"
+    [ -n "$mtime" ] && touch -m -d "$mtime" "$message"
+done


### PR DESCRIPTION
Uses offlineimap to allow you to:

- Import specific remote Gmail/IMAP folders to your MIAB mailbox (yes it preserves your Gmail labels)
- Export your MIAB mailbox folders to Gmail/IMAP (yes it also preserves your Gmail labels)
- View local & remote folders/labels

So yes you can use it to migrate from one Gmail account to another via MIAB!
Currently draft because the export hasn't been tested yet, but import works.

Has been crafted so that it could potentially be extended with a UI.

Process:

1. User enters login details and import/export
2. Info mode to get the folder lists and check authentication
3. User selects folders
4. Run with progress percentage output

Folder mappings are fixed and reciprocal
Plenty of guides out there on how to get a Gmail POP/IMAP password (no it's not the one you use to log in with normally)

In response to this:
https://support.google.com/a/answer/2855120