### PR TITLE
fix error when user_external version under 3.0.0

### DIFF
--- a/setup/nextcloud.sh
+++ b/setup/nextcloud.sh
@@ -95,7 +95,13 @@ InstallNextcloud() {
 	# Starting with Nextcloud 15, the app user_external is no longer included in Nextcloud core,
 	# we will install from their github repository.
 	if [ -n "$version_user_external" ]; then
-		wget_verify https://github.com/nextcloud-releases/user_external/releases/download/v$version_user_external/user_external-v$version_user_external.tar.gz $hash_user_external /tmp/user_external.tgz
+		IFS='.'
+		read -a checkVer <<< "$version_user_external"
+		if [ "${checkVer[0]}" -gt 2 ]; then
+			wget_verify https://github.com/nextcloud-releases/user_external/releases/download/v$version_user_external/user_external-v$version_user_external.tar.gz $hash_user_external /tmp/user_external
+		else
+			wget_verify https://github.com/nextcloud/user_external/releases/download/v$version_user_external/user_external-$version_user_external.tar.gz $hash_user_external /tmp/user_external
+		fi
 		tar -xf /tmp/user_external.tgz -C /usr/local/lib/owncloud/apps/
 		rm /tmp/user_external.tgz
 	fi


### PR DESCRIPTION
When updating power-mail-in-a-box, you can get a 404 error because version 3.0.0 and up use a different GitHub repo than everything below 3.0.0.
(as seen in issue 67 at https://github.com/ddavness/power-mailinabox/issues/67 )