### PR TITLE
Roundcube: Use Mail-in-a-Box admin API to drive password changes

### DIFF
--- a/setup/webmail.sh
+++ b/setup/webmail.sh
@@ -212,12 +212,11 @@ cp ${RCM_PLUGIN_DIR}/password/config.inc.php.dist \
 	${RCM_PLUGIN_DIR}/password/config.inc.php
 
 management/editconf.py ${RCM_PLUGIN_DIR}/password/config.inc.php -c "//" \
+	"\$config['password_driver'] = 'miab';" \
 	"\$config['password_minimum_length'] = 8;" \
-	"\$config['password_db_dsn'] = 'sqlite:///$STORAGE_ROOT/mail/users.sqlite';" \
-	"\$config['password_query'] = 'UPDATE users SET password=%P WHERE email=%u';" \
-	"\$config['password_algorithm'] = 'sha512-crypt';" \
-	"\$config['password_algorithm_prefix'] = '{SHA512-CRYPT}';" \
-	"\$config['password_dovecotpw_with_method'] = false;"
+	"\$config['password_miab_url'] = 'http://127.0.0.1:10222/';" \
+	"\$config['password_miab_user'] = '';" \
+	"\$config['password_miab_pass'] = '';"
 
 # so PHP can use doveadm, for the password changing plugin
 usermod -a -G dovecot www-data


### PR DESCRIPTION
Fixes #85
Related to mail-in-a-box/mailinabox#2185

The Mail-in-a-Box driver has a fallback mode where it can use the logged-in user's credentials to authenticate itself against the API. This is our next best solution (the first would be getting the root API key from `/var/lib/mailinabox/api.key`, but the driver does not support this and there isn't a fix we can do on our end).

**Right now there are two problems with this approach:**
- The endpoint used is admin-only (that means only admins can change their own password)
- - This is because this endpoint is used to change the password of any account. **Fixable on our end; if the user does not have admin privileges it can only change their own password**
- The authentication method used by the driver fails if the user has 2FA enabled
- - This is a security measure and I'm not willing to waive the 2FA part. The API as-is pretty much only allows admins to enroll in 2FA anyway, so they can still change their own password from within the admin panel, too. But removing 2FA from an admin user would keep their 2FA enrolment, and at this point they'd be unable to change their own password.
- - **Solution:** Allow non-admins to change their own passwords from within the admin panel (and also enroll in 2FA if they want to).