### PR TITLE
Allow webmail access from custom domain or multiple location

### DIFF
--- a/conf/nginx-primaryonly.conf
+++ b/conf/nginx-primaryonly.conf
@@ -33,6 +33,8 @@
 		fastcgi_split_path_info ^/mail(/.*)()$;
 		fastcgi_index index.php;
 		fastcgi_param SCRIPT_FILENAME /usr/local/lib/roundcubemail/$fastcgi_script_name;
+		# ensure roudcube session id's aren't leaked to other parts of the server
+		fastcgi_param PHP_VALUE "session.cookie_path=/mail/";
 		fastcgi_pass php-default;
 
 		# Outgoing mail also goes through this endpoint, so increase the maximum

--- a/setup/webmail.sh
+++ b/setup/webmail.sh
@@ -141,8 +141,6 @@ cat > $RCM_CONFIG <<EOF;
 \$config['password_charset'] = 'UTF-8';
 \$config['junk_mbox'] = 'Spam';
 
-/* ensure roudcube session id's aren't leaked to other parts of the server */
-\$config['session_path'] = '/mail/';
 /* prevent CSRF, requires php 7.3+ */
 \$config['session_samesite'] = 'Strict';
 \$config['quota_zero_as_unlimited'] = true;


### PR DESCRIPTION
By removing session_path  it becomes possible (you can set it up in a custom Nginx config file) to access Roundcube from multiple paths and/or custom domains. I believe it would be a big improvement for many people compared to the security risk that the leaking of session could have.